### PR TITLE
add support for unsigned fields

### DIFF
--- a/neo4j-etl/src/main/java/org/neo4j/etl/sql/metadata/SqlDataType.java
+++ b/neo4j-etl/src/main/java/org/neo4j/etl/sql/metadata/SqlDataType.java
@@ -8,13 +8,18 @@ public enum SqlDataType
 {
     BIT( Neo4jDataType.Byte ),
     INT( Neo4jDataType.Int ),
+    INT_UNSIGNED( Neo4jDataType.Int ),
     TINYINT( Neo4jDataType.Byte ),
+    TINYINT_UNSIGNED( Neo4jDataType.Byte ),
     SMALLINT( Neo4jDataType.Short ),
+    SMALLINT_UNSIGNED( Neo4jDataType.Short ),
     BIGINT( Neo4jDataType.Long ),
+    BIGINT_UNSIGNED( Neo4jDataType.Short ),
     FLOAT( Neo4jDataType.Float ),
     DOUBLE( Neo4jDataType.Double ),
     DECIMAL( Neo4jDataType.Float ),
     MEDIUMINT( Neo4jDataType.Int ),
+    MEDIUMINT_UNSIGNED( Neo4jDataType.Int ),
 
     CHAR( Neo4jDataType.String ),
     VARCHAR( Neo4jDataType.String ),
@@ -44,7 +49,7 @@ public enum SqlDataType
     {
         try
         {
-            return SqlDataType.valueOf( dataType.toUpperCase() );
+            return SqlDataType.valueOf( dataType.replaceAll(" ", "_").toUpperCase() );
         }
         catch ( NullPointerException e )
         {

--- a/neo4j-etl/src/test/java/org/neo4j/etl/sql/metadata/SqlDataTypeTest.java
+++ b/neo4j-etl/src/test/java/org/neo4j/etl/sql/metadata/SqlDataTypeTest.java
@@ -26,10 +26,14 @@ public class SqlDataTypeTest
     public void toNeo4jDataTypeMappingOfNumericTypes() throws Exception
     {
         assertThat( SqlDataType.INT.toNeo4jDataType(), is( Neo4jDataType.Int ) );
+        assertThat( SqlDataType.INT_UNSIGNED.toNeo4jDataType(), is( Neo4jDataType.Int ) );
         assertThat( SqlDataType.TINYINT.toNeo4jDataType(), is( Neo4jDataType.Byte ) );
         assertThat( SqlDataType.SMALLINT.toNeo4jDataType(), is( Neo4jDataType.Short ) );
+        assertThat( SqlDataType.SMALLINT_UNSIGNED.toNeo4jDataType(), is( Neo4jDataType.Short ) );
         assertThat( SqlDataType.MEDIUMINT.toNeo4jDataType(), is( Neo4jDataType.Int ) );
+        assertThat( SqlDataType.MEDIUMINT_UNSIGNED.toNeo4jDataType(), is( Neo4jDataType.Int ) );
         assertThat( SqlDataType.BIGINT.toNeo4jDataType(), is( Neo4jDataType.Long ) );
+        assertThat( SqlDataType.BIGINT_UNSIGNED.toNeo4jDataType(), is( Neo4jDataType.Long ) );
         assertThat( SqlDataType.FLOAT.toNeo4jDataType(), is( Neo4jDataType.Float ) );
         assertThat( SqlDataType.DOUBLE.toNeo4jDataType(), is( Neo4jDataType.Double ) );
         assertThat( SqlDataType.DECIMAL.toNeo4jDataType(), is( Neo4jDataType.Float ) );

--- a/neo4j-etl/src/test/java/org/neo4j/etl/sql/metadata/SqlDataTypeTest.java
+++ b/neo4j-etl/src/test/java/org/neo4j/etl/sql/metadata/SqlDataTypeTest.java
@@ -28,6 +28,7 @@ public class SqlDataTypeTest
         assertThat( SqlDataType.INT.toNeo4jDataType(), is( Neo4jDataType.Int ) );
         assertThat( SqlDataType.INT_UNSIGNED.toNeo4jDataType(), is( Neo4jDataType.Int ) );
         assertThat( SqlDataType.TINYINT.toNeo4jDataType(), is( Neo4jDataType.Byte ) );
+        assertThat( SqlDataType.TINYINT_UNSIGNED.toNeo4jDataType(), is( Neo4jDataType.Byte ) );
         assertThat( SqlDataType.SMALLINT.toNeo4jDataType(), is( Neo4jDataType.Short ) );
         assertThat( SqlDataType.SMALLINT_UNSIGNED.toNeo4jDataType(), is( Neo4jDataType.Short ) );
         assertThat( SqlDataType.MEDIUMINT.toNeo4jDataType(), is( Neo4jDataType.Int ) );


### PR DESCRIPTION
This fixed the issues I was having when importing our db.
Sample exception output : 

``` java
Creating MySQL to CSV mappings...
FINE: Connecting to database...
FINE: Connected to database
java.lang.IllegalArgumentException: No enum constant org.neo4j.etl.sql.metadata.SqlDataType.INT UNSIGNED
    at java.lang.Enum.valueOf(Enum.java:238)
    at org.neo4j.etl.sql.metadata.SqlDataType.valueOf(SqlDataType.java:7)
    at org.neo4j.etl.sql.metadata.SqlDataType.parse(SqlDataType.java:47)
    at org.neo4j.etl.sql.metadata.TableInfoAssembler.lambda$createColumnsMap$3(TableInfoAssembler.java:58)
    at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1691)
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
    at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
    at org.neo4j.etl.sql.metadata.TableInfoAssembler.createColumnsMap(TableInfoAssembler.java:61)
    at org.neo4j.etl.sql.metadata.TableInfoAssembler.createTableInfo(TableInfoAssembler.java:35)
    at org.neo4j.etl.commands.DatabaseInspector.buildSchema(DatabaseInspector.java:50)
    at org.neo4j.etl.commands.DatabaseInspector.buildSchemaExport(DatabaseInspector.java:38)
    at org.neo4j.etl.commands.mysql.GenerateMetadataMapping.call(GenerateMetadataMapping.java:99)
    at org.neo4j.etl.commands.mysql.GenerateMetadataMapping.call(GenerateMetadataMapping.java:27)
    at org.neo4j.etl.cli.mysql.ExportFromMySqlCli.createMetadataMappings(ExportFromMySqlCli.java:227)
    at org.neo4j.etl.cli.mysql.ExportFromMySqlCli.run(ExportFromMySqlCli.java:188)
    at org.neo4j.etl.util.CliRunner.run(CliRunner.java:42)
    at org.neo4j.etl.util.CliRunner.run(CliRunner.java:35)
    at org.neo4j.etl.NeoIntegrationCli.main(NeoIntegrationCli.java:43)
```
