### PR TITLE
UI improvements

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1005,6 +1005,10 @@ SYNOPSIS
 
         Where command-specific options [cmd-options] are:
 
+            ui:
+
+                --port &lt;port&gt;
+
             export:
 
                 --rdbms:url &lt;rdbms url&gt;
@@ -1052,7 +1056,7 @@ SYNOPSIS
 
         Where command-specific arguments &lt;cmd-args&gt; are:
 
-            ui: { start | stop }
+            ui: { start* | stop }
             export: [ &lt;table1 table2 ...&gt;... ]
             generate-metadata-mapping: [ &lt;table1 table2 ...&gt;... ]
             help: [ &lt;command&gt;... ]
@@ -1204,15 +1208,24 @@ DEPRECATED OPTIONS
             - Web application for editing RDBMS to Neo4j metadata mapping Json.
 
 SYNOPSIS
-        neo4j-etl ui { start | stop }
+        neo4j-etl ui { start* | stop }
+
+            --port &lt;port&gt;
 
 OPTIONS
 
         start:
-            Run the `neo4j-etl-ui` web server locally to make the UI available at http://localhost:3000.
+            Run the `neo4j-etl-ui` web server locally to make the UI available.
 
         stop:
-            Shutdown the `neo4j-etl-ui` web server.</code></pre>
+            Shutdown the `neo4j-etl-ui` web server.
+
+        --port &lt;port&gt;
+            UI connection port.
+
+        Note:
+
+            Passing no argument is equivalent to passing "start" (the default).</code></pre>
 </div></div>
 </div>
 <div class="sect2">
@@ -1842,7 +1855,7 @@ TODO: Create indexes and constraints related to not-primary key columns
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-08-22 19:05:11 CEST
+Last updated 2017-08-23 14:35:01 CEST
 </div>
 </div>
 </body>

--- a/docs/neo4j-etl-rdbms-ui.txt
+++ b/docs/neo4j-etl-rdbms-ui.txt
@@ -5,12 +5,21 @@ NAME
             - Web application for editing RDBMS to Neo4j metadata mapping Json.
 
 SYNOPSIS
-        neo4j-etl ui { start | stop }
+        neo4j-etl ui { start* | stop }
+
+            --port <port>
 
 OPTIONS
 
         start:
-            Run the `neo4j-etl-ui` web server locally to make the UI available at http://localhost:3000.
+            Run the `neo4j-etl-ui` web server locally to make the UI available.
 
         stop:
             Shutdown the `neo4j-etl-ui` web server.
+
+        --port <port>
+            UI connection port.
+
+        Note:
+
+            Passing no argument is equivalent to passing "start" (the default).

--- a/docs/neo4j-etl-rdbms.txt
+++ b/docs/neo4j-etl-rdbms.txt
@@ -12,6 +12,10 @@ SYNOPSIS
 
         Where command-specific options [cmd-options] are:
 
+            ui:
+
+                --port <port>
+
             export:
 
                 --rdbms:url <rdbms url>
@@ -59,7 +63,7 @@ SYNOPSIS
 
         Where command-specific arguments <cmd-args> are:
 
-            ui: { start | stop }
+            ui: { start* | stop }
             export: [ <table1 table2 ...>... ]
             generate-metadata-mapping: [ <table1 table2 ...>... ]
             help: [ <command>... ]

--- a/docs/neo4j-etl.html
+++ b/docs/neo4j-etl.html
@@ -1003,13 +1003,18 @@ DEPRECATED OPTIONS
 SYNOPSIS
         neo4j-etl ui { start | stop }
 
+            --port &lt;port&gt;
+
 OPTIONS
 
         start:
             Run the `neo4j-etl-ui` web server locally to make the UI available at http://localhost:3000.
 
         stop:
-            Shutdown the `neo4j-etl-ui` web server.</code></pre>
+            Shutdown the `neo4j-etl-ui` web server.
+
+        --port &lt;port&gt;
+            Port number to use for connection to the UI.</code></pre>
 </div></div>
 </div>
 <div class="sect2">
@@ -1463,7 +1468,7 @@ root@692c446a274b:~# exit
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-08-23 00:29:44 CEST
+Last updated 2017-08-23 14:35:01 CEST
 </div>
 </div>
 </body>

--- a/neo4j-etl-cli/src/main/java/org/neo4j/etl/cli/ui/UserInterfaceCli.java
+++ b/neo4j-etl-cli/src/main/java/org/neo4j/etl/cli/ui/UserInterfaceCli.java
@@ -12,9 +12,15 @@ import java.util.List;
 @Command(name = "ui", description = "Starting Neo4j ETL UI Node.JS server.")
 public class UserInterfaceCli implements Runnable
 {
-    @Arguments(description = "start / stop the neo4j-etl ui server",
+    @Arguments(description = "Start / Stop the neo4j-etl ui server.",
             title = "start / stop server")
     protected List<String> arguments;
+
+    @Option(type = OptionType.COMMAND,
+            name = {"--port"},
+            description = "Port number to use for connection to the ui.",
+            title = "ui port")
+    protected long port = 3000;
 
     @Option(type = OptionType.COMMAND,
             name = {"--debug"},
@@ -26,14 +32,9 @@ public class UserInterfaceCli implements Runnable
     {
         try
         {
-            if ( arguments == null || arguments.size() != 1)
-            {
-                wrongArguments();
-            }
+            String command = ( arguments != null && arguments.size() > 0 ) ? arguments.get(0) : "start";
 
-            String command = arguments.get(0);
-
-            UserInterfaceProcessHandler uiProcess = new UserInterfaceProcessHandler();
+            UserInterfaceProcessHandler uiProcess = new UserInterfaceProcessHandler( this.port );
 
             if ( command.equalsIgnoreCase( "start" ) )
             {
@@ -45,17 +46,12 @@ public class UserInterfaceCli implements Runnable
             }
             else
             {
-                wrongArguments();
+                throw new IllegalArgumentException( "Wrong arguments. Usage: ./bin/neo4j-etl ui { start | stop }" );
             }
         }
         catch ( Exception e )
         {
             CliRunner.handleException( e, debug );
         }
-    }
-
-    private void wrongArguments()
-    {
-        throw new IllegalArgumentException("Wrong arguments. Usage: ./bin/neo4j-etl ui { start | stop }");
     }
 }

--- a/neo4j-etl-cli/src/main/java/org/neo4j/etl/cli/ui/UserInterfaceEventHandler.java
+++ b/neo4j-etl-cli/src/main/java/org/neo4j/etl/cli/ui/UserInterfaceEventHandler.java
@@ -9,9 +9,9 @@ import static java.lang.String.format;
 public class UserInterfaceEventHandler implements UserInterfaceEvents
 {
     @Override
-    public void onStartingServer( Path webappDirectory )
+    public void onStartingServer( Path webappDirectory, String port )
     {
-        CliRunner.print( "Starting Node.JS server..." );
+        CliRunner.print( format( "Starting Node.JS server on port %s...", port ) );
         CliRunner.print( format( "Webapp directory: %s", webappDirectory ) );
     }
 

--- a/neo4j-etl-cli/src/main/java/org/neo4j/etl/cli/ui/UserInterfaceEvents.java
+++ b/neo4j-etl-cli/src/main/java/org/neo4j/etl/cli/ui/UserInterfaceEvents.java
@@ -4,7 +4,7 @@ import java.nio.file.Path;
 
 public interface UserInterfaceEvents
 {
-    void onStartingServer( Path webappDirectory );
+    void onStartingServer( Path webappDirectory, String port );
 
     void onServerStarted( long pid );
 

--- a/neo4j-etl-cli/src/main/java/org/neo4j/etl/commands/ui/NodeJsServer.java
+++ b/neo4j-etl-cli/src/main/java/org/neo4j/etl/commands/ui/NodeJsServer.java
@@ -39,7 +39,7 @@ public class NodeJsServer extends Thread
 
             Path nodeScript = Paths.get( rootDir, "ui", "bin/www");
 
-            events.onStartingServer( nodeScript );
+            events.onStartingServer( nodeScript, System.getenv( "NEO4J_ETL_UI_PORT" ) );
 
             nodeJS = NodeJS.createNodeJS();
 

--- a/neo4j-etl-cli/src/main/java/org/neo4j/etl/commands/ui/UserInterfaceProcessHandler.java
+++ b/neo4j-etl-cli/src/main/java/org/neo4j/etl/commands/ui/UserInterfaceProcessHandler.java
@@ -1,5 +1,6 @@
 package org.neo4j.etl.commands.ui;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.neo4j.etl.util.OperatingSystem;
 
 import java.net.URL;
@@ -8,8 +9,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
+
 public class UserInterfaceProcessHandler
 {
+    private long port;
+
+    public UserInterfaceProcessHandler( long port )
+    {
+        this.port = port;
+    }
+
     public void start() throws Exception
     {
         URL[] urls = ( ( URLClassLoader ) ClassLoader.getSystemClassLoader() ).getURLs();
@@ -17,10 +27,26 @@ public class UserInterfaceProcessHandler
                 .stream()
                 .map( url -> url.getFile() )
                 .collect(Collectors.joining( System.getProperty("path.separator") ) );
+
         List<String> command = Arrays.asList( "java", "-cp", classpath, "org.neo4j.etl.commands.ui.UserInterfaceServer" );
         ProcessBuilder processBuilder = new ProcessBuilder( command );
+        processBuilder.environment().put( "NEO4J_ETL_UI_PORT", String.valueOf( this.port ) );
         processBuilder.inheritIO();
         processBuilder.start();
+
+        Thread.sleep( 2000 );
+
+        String openCommand;
+
+        if ( OperatingSystem.isWindows() )
+            openCommand = "iexplorer.exe";
+        else if ( OperatingSystem.isLinux() )
+            openCommand = "sensible-browser";
+        else
+            openCommand = "open";
+
+        ProcessBuilder browser = new ProcessBuilder( Arrays.asList( openCommand, format( "http://localhost:%s", this.port ) ) );
+        browser.start();
     }
 
     public void stop() throws Exception

--- a/neo4j-etl-ui/bin/www
+++ b/neo4j-etl-ui/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.NEO4J_ETL_UI_PORT || '3000');
 app.set('port', port);
 
 /**

--- a/neo4j-etl/src/main/java/org/neo4j/etl/util/OperatingSystem.java
+++ b/neo4j-etl/src/main/java/org/neo4j/etl/util/OperatingSystem.java
@@ -4,6 +4,11 @@ public class OperatingSystem
 {
     public static boolean isWindows()
     {
-        return System.getProperty( "os.name" ).startsWith( "Windows" );
+        return System.getProperty( "os.name" ).toLowerCase().startsWith( "windows" );
+    }
+
+    public static boolean isLinux()
+    {
+        return System.getProperty( "os.name" ).toLowerCase().startsWith( "linux" );
     }
 }


### PR DESCRIPTION
- default to start parameter
- also show the port when starting the server
- make the port configurable
- launch the "open" command for that URL per OS
. _linux_: `sensible-browser http://localhost:<port>`
. _mac_: `open http://localhost:<port>`
. _windows_: `iexplorer.exe http://localhost:<port>`

